### PR TITLE
Simplify build script even further; update gradle dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,16 @@ buildscript {
 
         dependencies {
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-            classpath 'com.typelead:gradle-eta:0.5.0'
+            classpath 'com.typelead:gradle-eta:0.5.2'
         }
     }
 }
 
-repositories {
-    mavenLocal()
-    mavenCentral()
+allprojects {
+  repositories {
+      mavenLocal()
+      mavenCentral()
+  }
 }
 
 group 'io.nickseagull'

--- a/ws-kt/build.gradle
+++ b/ws-kt/build.gradle
@@ -3,10 +3,6 @@ apply plugin: 'application'
 
 mainClassName = 'App'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile project(':ws-eta')


### PR DESCRIPTION
`gradle-eta-0.5.2` fixes the bug with multi-project builds. Running `./gradlew run` gave the correct output of `3` for me.